### PR TITLE
Rpc channels

### DIFF
--- a/lib/message.ts
+++ b/lib/message.ts
@@ -18,6 +18,7 @@ export enum MsgType {
 export interface IMsgRpcCall {
   // Warning: Do NOT change fields (see warning above).
   mtype: MsgType.RpcCall;
+  mpipes?: string[];
   reqId?: number;       // Omitted when the method should not return a response.
   iface: string;
   meth: string;
@@ -28,6 +29,7 @@ export interface IMsgRpcCall {
 export interface IMsgRpcRespData {
   // Warning: Do NOT change fields (see warning above).
   mtype: MsgType.RpcRespData;
+  mpipes?: string[];
   reqId: number;
   data?: any;
 }
@@ -36,6 +38,7 @@ export interface IMsgRpcRespData {
 export interface IMsgRpcRespErr {
   // Warning: Do NOT change fields (see warning above).
   mtype: MsgType.RpcRespErr;
+  mpipes?: string[];
   reqId: number;
   mesg: string;
   code?: string;
@@ -44,6 +47,7 @@ export interface IMsgRpcRespErr {
 // Message describing a non-RPC message.
 export interface IMsgCustom {
   mtype: MsgType.Custom;
+  mpipes?: string[];
   data: any;
 }
 

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -40,16 +40,18 @@ describe("ts-rpc", () => {
     assert.equal(await stub.getGreeting("World"), "Hello, World!");
   });
 
-  it("should support rpc channeling ", async () => {
+  it("should support rpc pipes ", async () => {
     const [abRpc, bRpc] = createRpcPair();
     const [acRpc, cRpc] = createRpcPair();
-    abRpc.pipe("b2c", acRpc);
-    const b2cRpc = cRpc.pipe("b2c");
-    const c2bRpc = bRpc.pipe("b2c");
+    Rpc.pipe("b2c", abRpc, acRpc);
+    const b2cRpc = cRpc.pipeEndpoint("b2c");
+    const c2bRpc = bRpc.pipeEndpoint("b2c");
     await assertHelloWorld(abRpc, bRpc);
     await assertHelloWorld(acRpc, cRpc);
     await assertHelloWorld(b2cRpc, c2bRpc);
   });
+
+  // todo: test more complex pipes
 
 });
 

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -40,22 +40,45 @@ describe("ts-rpc", () => {
     assert.equal(await stub.getGreeting("World"), "Hello, World!");
   });
 
-  it("should support rpc pipes ", async () => {
-    const [abRpc, bRpc] = createRpcPair();
-    const [acRpc, cRpc] = createRpcPair();
-    Rpc.pipe("b2c", abRpc, acRpc);
-    const b2cRpc = cRpc.pipeEndpoint("b2c");
-    const c2bRpc = bRpc.pipeEndpoint("b2c");
-    await assertHelloWorld(abRpc, bRpc);
-    await assertHelloWorld(acRpc, cRpc);
-    await assertHelloWorld(b2cRpc, c2bRpc);
-  });
+  describe("pipe", () => {
 
-  // todo: test more complex pipes
+    function pipeEndpointsThrough(a: IEndpoint, b: IEndpoint, {through: c}: {through: IEndpoint}) {
+      const a2b = a.name + "2" + b.name;
+      Rpc.pipe(a2b, c.to[a.name], c.to[b.name]);
+      a.to[b.name] = Rpc.pipeEndpoint(a2b, b.to[c.name]);
+      b.to[a.name] = Rpc.pipeEndpoint(a2b, a.to[c.name]);
+    }
+
+    const A: IEndpoint = {name: "a", to: {}};
+    const B: IEndpoint = {name: "b", to: {}};
+    const C: IEndpoint = {name: "c", to: {}};
+
+    linkEndpoints(A, B);
+    linkEndpoints(A, C);
+    pipeEndpointsThrough(B, C, {through: A});
+
+    describe("(B) to (C) through (A)", () => {
+      shouldBeValid(B, C);
+      shouldNotBreak([A, C], [A, B]);
+    });
+
+    describe("more complex pipes: (D) to (C) though (B)", () => {
+
+      const D: IEndpoint = {name: "d", to: {}};
+
+      linkEndpoints(D, B);
+      pipeEndpointsThrough(D, C, {through: B});
+
+      shouldBeValid(D, C);
+      shouldNotBreak([A, C], [A, B], [B, C], [B, D]);
+    });
+
+  });
 
 });
 
 async function assertHelloWorld(aRpc: Rpc, bRpc: Rpc) {
+  aRpc.unregisterImpl("my-greeting");
   aRpc.registerImpl("my-greeting", new MyGreeting());
   const stub = bRpc.getStub<IGreet>("my-greeting");
   assert.equal(await stub.getGreeting("World"), "Hello, World!");
@@ -67,4 +90,46 @@ function createRpcPair(): [Rpc, Rpc] {
   aRpc.start((msg) => bRpc.receiveMessage(msg));
   bRpc.start((msg) => aRpc.receiveMessage(msg));
   return [aRpc, bRpc];
+}
+
+function basicTests(A: IEndpoint, B: IEndpoint) {
+  const aRpc = A.to[B.name];
+  const bRpc = B.to[A.name];
+  it("should support hello world", async () => {
+    await assertHelloWorld(aRpc, bRpc);
+  });
+
+  it("should support calling function", async () => {
+    aRpc.unregisterFunc("foo");
+    aRpc.registerFunc("foo", async (name: string) => `Yo ${name}!`);
+    assert.equal(await bRpc.callRemoteFunc("foo", "Santa"), "Yo Santa!");
+  });
+}
+
+function linkEndpoints(A: IEndpoint, B: IEndpoint) {
+  [A.to[B.name], B.to[A.name]] = createRpcPair();
+}
+
+// some test internal types
+interface IEndpoint {
+  name: string;
+  to: {[name: string]: Rpc};
+}
+
+function shouldBeValid(a: IEndpoint, b: IEndpoint) {
+  describe(`Should be valid ${formatEndpoints(a, b)}`, () => basicTests(a, b));
+}
+
+function shouldNotBreak(...abs: IEndpoint[][]) {
+  for (const [a, b] of abs) {
+    describe(`should not break ${formatEndpoints(a, b)}`, () => basicTests(a, b));
+  }
+}
+
+function formatEndpoints(a: IEndpoint, b: IEndpoint) {
+  return `${formatEndpoint(a)} to ${formatEndpoint(b)}`;
+}
+
+function formatEndpoint(a: IEndpoint): string {
+  return `(${a.name.toUpperCase()})`;
 }


### PR DESCRIPTION
Pipes allows rpc over rpc. 

We've being routing Rpc messages over channels in Grist, and I feel the way I do it is not really convincing. Rpc pipes do that, with only slight addition to the message interface and a minimalist routing mechanism.

The solution adds `Rpc.pipe` and `Rpc.pipeEndpoint` static functions to the interface, and as well a `pipeFunction` method. It includes unit-tests that covers basic scenario and a more complex one (piping over piped rpc). But the module is still missing more comprehensive test suit to assert that an rpc channel is valid.

I put some effort trying to write unit-test that are readable (I found testing routing over a graph could easy become very messy, even though topology is pretty simple). But I'm not sure I got any close to that, so please let me know if scheming you through them could help.

The branch includes as well the `unregisterFunc(...)` to make it more consistent with its `[un]registerImpl` counterpart.