### PR TITLE
automatic forwarding

### DIFF
--- a/lib/message.ts
+++ b/lib/message.ts
@@ -18,6 +18,7 @@ export enum MsgType {
 export interface IMsgRpcCall {
   // Warning: Do NOT change fields (see warning above).
   mtype: MsgType.RpcCall;
+  mdest?: string;       // Optional destination for forwarding calls.
   reqId?: number;       // Omitted when the method should not return a response.
   iface: string;
   meth: string;
@@ -44,6 +45,7 @@ export interface IMsgRpcRespErr {
 // Message describing a non-RPC message.
 export interface IMsgCustom {
   mtype: MsgType.Custom;
+  mdest?: string;       // Optional destination for forwarding calls.
   data: any;
 }
 

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -47,10 +47,14 @@
  *
  * Forwarding
  * ----------
- * Rpc.registerForwarder() method allows one Rpc object to forward all calls to interfaces with a
- * given prefix to a different Rpc object. The intended usage is when Rpc connects A to B, and B
- * to C. Then B can use registerForwarder to expose A's interfaces to C (or C's to A) without
- * having to know what exactly they are.
+ * Rpc.registerForwarder() along with methods with "-Forward" suffix allow one Rpc object to
+ * forward calls and messages to another Rpc object. The intended usage is when Rpc connects A to
+ * B, and B to C. Then B can use registerForwarder to expose A's interfaces to C (or C's to A)
+ * without having to know what exactly they are.
+ *
+ * E.g. with A.registerImpl("A-name", ...) and B.registerForwarder("b2a", A), we may now call
+ * C.getStubForward("b2a", "A-name") to get a stub that will forward calls to A, as well as
+ * C.postMessageForward("b2a", msg) to have the message received by A.
  *
  * TODO We may want to support progress callbacks, perhaps by supporting arbitrary callbacks as
  * parameters. (Could be implemented by allowing "meth" to be [reqId, paramPath]) It would be nice
@@ -69,8 +73,8 @@ export class Rpc extends EventEmitter {
   private _sendMessage: SendMessageCB;
   private _inactiveQueue: IMessage[] | null;
   private _logger: IRpcLogger;
-  private _implMap: {[name: string]: Implementation} = {};
-  private _prefixList: Implementation[] = [];
+  private _implMap: Map<string, Implementation> = new Map();
+  private _forwarders: Map<string, ImplementationFwd> = new Map();
   private _pendingCalls: Map<number, ICallObj> = new Map();
   private _nextRequestId = 1;
 
@@ -116,8 +120,11 @@ export class Rpc extends EventEmitter {
   /**
    * Messaging interface: send data to the other side, to be emitted there as a "message" event.
    */
-  public async postMessage(data: any): Promise<void> {
+  public postMessage(data: any): Promise<void> { return this.postMessageForward("", data); }
+
+  public async postMessageForward(fwdDest: string, data: any): Promise<void> {
     const msg: IMsgCustom = {mtype: MsgType.Custom, data};
+    if (fwdDest) { msg.mdest = fwdDest; }
     await this._sendMessage(msg);
   }
 
@@ -129,12 +136,12 @@ export class Rpc extends EventEmitter {
   public registerImpl<Iface extends any>(name: string, impl: any): void;
   public registerImpl<Iface>(name: string, impl: Iface, checker: tic.Checker): void;
   public registerImpl(name: string, impl: any, checker?: tic.Checker): void {
-    if (this._implMap.hasOwnProperty(name)) {
+    if (this._implMap.has(name)) {
       throw new Error(`Rpc.registerImpl has already been called for ${name}`);
     }
     const invokeImpl = (call: IMsgRpcCall) => impl[call.meth](...call.args);
     if (!checker) {
-      this._implMap[name] = {name, invokeImpl, argsCheckers: null};
+      this._implMap.set(name, {name, invokeImpl, argsCheckers: null});
     } else {
       const ttype = getType(checker);
       if (!(ttype instanceof tic.TIface)) {
@@ -146,23 +153,24 @@ export class Rpc extends EventEmitter {
           argsCheckers[prop.name] = checker.methodArgs(prop.name);
         }
       }
-      this._implMap[name] = {name, invokeImpl, argsCheckers};
+      this._implMap.set(name, {name, invokeImpl, argsCheckers});
     }
   }
 
-  public registerForwarder(srcPrefix: string, destPrefix: string, destRpc: Rpc): void {
-    const invokeImpl = (call: IMsgRpcCall) => {
-      const iface = destPrefix + call.iface.slice(srcPrefix.length);
-      return destRpc._makeCall(iface, call.meth, call.args, anyChecker);
-    };
-    this._prefixList.push({name: srcPrefix, invokeImpl, argsCheckers: null});
+  public registerForwarder(fwdName: string, destRpc: Rpc, fwdDest: string = ""): void {
+    this._forwarders.set(fwdName, {
+      name: "[FWD]" + fwdName,
+      argsCheckers: null,
+      invokeImpl: (c: IMsgRpcCall) => destRpc._makeCall(c.iface, c.meth, c.args, anyChecker, fwdDest),
+      forwardMessage: (msg: IMsgCustom) => destRpc.postMessageForward(fwdDest, msg.data),
+    });
   }
 
   /**
    * Unregister an implementation, if one was registered with this name.
    */
   public unregisterImpl(name: string): void {
-    delete this._implMap[name];
+    this._implMap.delete(name);
   }
 
   /**
@@ -173,11 +181,17 @@ export class Rpc extends EventEmitter {
   public getStub<Iface extends any>(name: string): any;
   public getStub<Iface>(name: string, checker: tic.Checker): Iface;
   public getStub(name: string, checker?: tic.Checker): any {
+    return this.getStubForward("", name, checker!);
+  }
+
+  public getStubForward<Iface extends any>(fwdDest: string, name: string): any;
+  public getStubForward<Iface>(fwdDest: string, name: string, checker: tic.Checker): Iface;
+  public getStubForward(fwdDest: string, name: string, checker?: tic.Checker): any {
     if (!checker) {
       // TODO Test, then explain how this works.
       return new Proxy({}, {
         get: (target, property: string, receiver) => {
-          return (...args: any[]) => this._makeCall(name, property, args, anyChecker);
+          return (...args: any[]) => this._makeCall(name, property, args, anyChecker, fwdDest);
         },
       });
     } else {
@@ -189,7 +203,7 @@ export class Rpc extends EventEmitter {
       for (const prop of ttype.props) {
         if (prop.ttype instanceof tic.TFunc) {
           const resultChecker = checker.methodResult(prop.name);
-          api[prop.name] = (...args: any[]) => this._makeCall(name, prop.name, args, resultChecker);
+          api[prop.name] = (...args: any[]) => this._makeCall(name, prop.name, args, resultChecker, fwdDest);
         }
       }
       return api;
@@ -214,10 +228,15 @@ export class Rpc extends EventEmitter {
    * Call a remote function registered with registerFunc. Does no type checking.
    */
   public callRemoteFunc(name: string, ...args: any[]): Promise<any> {
-    return this._makeCall(name, "invoke", args, anyChecker);
+    return this.callRemoteFuncForward("", name, ...args);
   }
 
-  private _makeCall(iface: string, meth: string, args: any[], resultChecker: tic.Checker): Promise<any> {
+  public callRemoteFuncForward(fwdDest: string, name: string, ...args: any[]): Promise<any> {
+    return this._makeCall(name, "invoke", args, anyChecker, fwdDest);
+  }
+
+  private _makeCall(iface: string, meth: string, args: any[], resultChecker: tic.Checker,
+                    fwdDest: string): Promise<any> {
     return new Promise((resolve, reject) => {
       const reqId = this._nextRequestId++;
       const callObj: ICallObj = {reqId, iface, meth, resolve, reject, resultChecker};
@@ -227,6 +246,7 @@ export class Rpc extends EventEmitter {
       // succeeds, we save {resolve,reject} to resolve _makeCall when we get back a response.
       this._info(callObj, "RPC_CALLING");
       const msg: IMsgRpcCall = {mtype: MsgType.RpcCall, reqId, iface, meth, args};
+      if (fwdDest) { msg.mdest = fwdDest; }
       Promise.resolve().then(() => this._sendMessage(msg)).catch((err) => {
         this._pendingCalls.delete(reqId);
         reject(err);
@@ -239,19 +259,34 @@ export class Rpc extends EventEmitter {
       case MsgType.RpcCall: { this._onMessageCall(msg); return; }
       case MsgType.RpcRespData:
       case MsgType.RpcRespErr: { this._onMessageResp(msg); return; }
-      case MsgType.Custom: { this.emit("message", msg.data); return; }
+      case MsgType.Custom: { this._onCustomMessage(msg); return; }
+    }
+  }
+
+  private _onCustomMessage(msg: IMsgCustom): void {
+    if (msg.mdest) {
+      const impl = this._forwarders.get(msg.mdest);
+      if (!impl) {
+        this._warn(null, "RPC_UNKNOWN_FORWARD_DEST", "Unknown forward destination");
+      } else {
+        impl.forwardMessage(msg);
+      }
+    } else {
+      this.emit("message", msg.data);
     }
   }
 
   private async _onMessageCall(call: IMsgRpcCall): Promise<void> {
     let impl: Implementation|undefined;
-    if (this._implMap.hasOwnProperty(call.iface)) {
-      impl = this._implMap[call.iface];
-    } else {
-      // Note that this relies on _prefixMap maintaining entries in insertion order.
-      impl = this._prefixList.find((_impl) => call.iface.startsWith(_impl.name));
+    if (call.mdest) {
+      impl = this._forwarders.get(call.mdest);
       if (!impl) {
-        return this._failCall(call, "RPC_UNKNOWN_INTERFACE", `Unknown interface ${call.iface}`);
+        return this._failCall(call, "RPC_UNKNOWN_FORWARD_DEST", "Unknown forward destination");
+      }
+    } else {
+      impl = this._implMap.get(call.iface);
+      if (!impl) {
+        return this._failCall(call, "RPC_UNKNOWN_INTERFACE", "Unknown interface");
       }
     }
 
@@ -349,6 +384,10 @@ interface Implementation {
   argsCheckers: null | {
     [name: string]: tic.Checker;
   };
+}
+
+interface ImplementationFwd extends Implementation {
+  forwardMessage: (msg: IMsgCustom) => Promise<void>;
 }
 
 interface ICallObj {

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -157,8 +157,7 @@ export class Rpc extends EventEmitter {
     }
   }
 
-  public registerForwarder(fwdName: string, destRpc: Rpc): void {
-    const fwdDest = fwdName;
+  public registerForwarder(fwdName: string, destRpc: Rpc, fwdDest?: string = fwdName): void {
     this._forwarders.set(fwdName, {
       name: "[FWD]" + fwdName,
       argsCheckers: null,

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -45,6 +45,12 @@
  * stubs or for a particular one. If a response to a call does not arrive within the timeout, the
  * call gets rejected, and the rejection Error will have a "code" property set to "TIMEOUT".
  *
+ * Pipes
+ * -----
+ * Pipes allow to create rpc channels over several others rpc channels. In a common usage example,
+ * an endpoint (A) has two rpc channels connected to two endpoint (B) and (C), Rpc pipes make it
+ * possible to create an rpc between (B) and (C) with all messages going through (A).
+ *
  * TODO We may want to support progress callbacks, perhaps by supporting arbitrary callbacks as
  * parameters. (Could be implemented by allowing "meth" to be [reqId, paramPath]) It would be nice
  * to allow the channel to report progress too, e.g. to report progress of uploading large files.
@@ -62,7 +68,8 @@ export class Rpc extends EventEmitter {
   private _sendMessage: SendMessageCB;
   private _inactiveQueue: IMessage[] | null;
   private _logger: IRpcLogger;
-  private _implMap: {[name: string]: Implementation} = {};
+  private _implMap: Map<string, Implementation> = new Map();
+  private _prefixMap: Map<string, Implementation> = new Map();
   private _pendingCalls: Map<number, ICallObj> = new Map();
   private _nextRequestId = 1;
 
@@ -121,11 +128,12 @@ export class Rpc extends EventEmitter {
   public registerImpl<Iface extends any>(name: string, impl: any): void;
   public registerImpl<Iface>(name: string, impl: Iface, checker: tic.Checker): void;
   public registerImpl(name: string, impl: any, checker?: tic.Checker): void {
-    if (this._implMap.hasOwnProperty(name)) {
+    if (this._implMap.has(name)) {
       throw new Error(`Rpc.registerImpl has already been called for ${name}`);
     }
+    const invokeImpl = async (call: IMsgRpcCall) => impl[call.meth](...call.args);
     if (!checker) {
-      this._implMap[name] = {name, impl, argsCheckers: null};
+      this._implMap.set(name, {name, invokeImpl, argsCheckers: null});
     } else {
       const ttype = getType(checker);
       if (!(ttype instanceof tic.TIface)) {
@@ -137,15 +145,26 @@ export class Rpc extends EventEmitter {
           argsCheckers[prop.name] = checker.methodArgs(prop.name);
         }
       }
-      this._implMap[name] = {name, impl, argsCheckers};
+      this._implMap.set(name, {name, invokeImpl, argsCheckers});
     }
+  }
+
+  public registerForwarder(srcPrefix: string, destPrefix: string, destRpc: Rpc): void {
+    if (!srcPrefix.endsWith(".")) {
+      throw new Error("Rpc.registerForwarders requires a prefix that ends in period (.)");
+    }
+    const invokeImpl = (call: IMsgRpcCall) => {
+      const iface = destPrefix + call.iface.slice(srcPrefix.length);
+      return destRpc._makeCall(iface, call.meth, call.args, anyChecker);
+    };
+    this._prefixMap.set(srcPrefix.slice(0, -1), {name: srcPrefix, invokeImpl, argsCheckers: null});
   }
 
   /**
    * Unregister an implementation, if one was registered with this name.
    */
   public unregisterImpl(name: string): void {
-    delete this._implMap[name];
+    this._implMap.delete(name);
   }
 
   /**
@@ -187,6 +206,13 @@ export class Rpc extends EventEmitter {
   }
 
   /**
+   * Unregister a afunction, if one was registered with this name.
+   */
+  public unregisterFunc(name: string): void {
+    return this.unregisterImpl(name);
+  }
+
+  /**
    * Call a remote function registered with registerFunc. Does no type checking.
    */
   public callRemoteFunc(name: string, ...args: any[]): Promise<any> {
@@ -220,11 +246,17 @@ export class Rpc extends EventEmitter {
   }
 
   private async _onMessageCall(call: IMsgRpcCall): Promise<void> {
-    if (!this._implMap.hasOwnProperty(call.iface)) {
-      return this._failCall(call, "RPC_UNKNOWN_INTERFACE", "Unknown interface");
+    let impl = this._implMap.get(call.iface);
+    if (!impl) {
+      const prefix = getPrefix(call.iface);
+      if (prefix) {
+        impl = this._prefixMap.get(prefix);
+      }
+    }
+    if (!impl) {
+      return this._failCall(call, "RPC_UNKNOWN_INTERFACE", `Unknown interface ${call.iface}`);
     }
 
-    const impl: Implementation = this._implMap[call.iface];
     if (!impl.argsCheckers) {
       // No call or argument checking.
     } else {
@@ -246,7 +278,7 @@ export class Rpc extends EventEmitter {
     this._info(call, "RPC_ONCALL");
     let result;
     try {
-      result = await impl.impl[call.meth](...call.args);
+      result = await impl.invokeImpl(call);
     } catch (e) {
       return this._failCall(call, e.code, e.message, "RPC_ONCALL_ERROR");
     }
@@ -315,7 +347,7 @@ function inactiveSend(msg: IMessage): void {
 
 interface Implementation {
   name: string;
-  impl: any;    // The actual object implementing the interface described by desc.
+  invokeImpl: (call: IMsgRpcCall) => Promise<any>;
   argsCheckers: null | {
     [name: string]: tic.Checker;
   };
@@ -364,4 +396,9 @@ const anyChecker: tic.Checker = checkerAnyResult;
 // TODO Hack: expose this in ts-interface-checker
 function getType(checker: tic.Checker): tic.TType {
   return (checker as any).ttype;
+}
+
+function getPrefix(str: string): string|null {
+  const pos = str.indexOf(".");
+  return pos === -1 ? null : str.slice(0, pos);
 }

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -120,9 +120,16 @@ export class Rpc extends EventEmitter {
   /**
    * Messaging interface: send data to the other side, to be emitted there as a "message" event.
    */
-  public postMessage(data: any): Promise<void> { return this.postMessageForward("", data); }
 
-  public async postMessageForward(fwdDest: string, data: any): Promise<void> {
+  public async postMessage(data: any): Promise<void>;
+  public async postMessage(fwdDest: string, data: any): Promise<void>;
+  public async postMessage(...args: any[]): Promise<void> {
+    let fwdDest = "";
+    let data = args[0];
+    if (args.length === 2) {
+      fwdDest = args[0];
+      data = args[1];
+    }
     const msg: IMsgCustom = {mtype: MsgType.Custom, data};
     if (fwdDest) { msg.mdest = fwdDest; }
     await this._sendMessage(msg);
@@ -157,12 +164,12 @@ export class Rpc extends EventEmitter {
     }
   }
 
-  public registerForwarder(fwdName: string, destRpc: Rpc, fwdDest?: string = fwdName): void {
+  public registerForwarder(fwdName: string, destRpc: Rpc, fwdDest: string = fwdName): void {
     this._forwarders.set(fwdName, {
       name: "[FWD]" + fwdName,
       argsCheckers: null,
       invokeImpl: (c: IMsgRpcCall) => destRpc._makeCall(c.iface, c.meth, c.args, anyChecker, fwdDest),
-      forwardMessage: (msg: IMsgCustom) => destRpc.postMessageForward(fwdDest, msg.data),
+      forwardMessage: (msg: IMsgCustom) => destRpc.postMessage(fwdDest, msg.data),
     });
   }
 

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -90,7 +90,7 @@ describe("ts-rpc", () => {
     assert.deepEqual(await p, {hello: 1});
 
     p = waitForEvent(BtoA, "message");
-    await CtoA.postMessageForward("foo", {hello: 2});
+    await CtoA.postMessage("foo", {hello: 2});
     assert.deepEqual(await p, {hello: 2});
 
     p = waitForEvent(BtoD, "message");
@@ -98,7 +98,7 @@ describe("ts-rpc", () => {
     assert.deepEqual(await p, {world: 3});
 
     p = waitForEvent(CtoA, "message");
-    await DtoB.postMessageForward("bar", {world: 4});
+    await DtoB.postMessage("bar", {world: 4});
     assert.deepEqual(await p, {world: 4});
   });
 });

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -60,7 +60,7 @@ describe("ts-rpc", () => {
     AtoC.registerForwarder("foo", AtoB);
 
     // Allow D to call to C via B and A with "bar" forwarder.
-    BtoD.registerForwarder("bar", BtoA, "bar");
+    BtoD.registerForwarder("bar", BtoA);
     AtoB.registerForwarder("bar", AtoC);
 
     BtoA.registerImpl("my-greeting", new MyGreeting(" [from B]"));
@@ -71,17 +71,17 @@ describe("ts-rpc", () => {
 
     assert.equal(await AtoB.getStub<IGreet>("my-greeting").getGreeting("World"),
       "Hello, World! [from B]");
-    assert.equal(await CtoA.getStubForward<IGreet>("foo", "my-greeting").getGreeting("World"),
+    assert.equal(await CtoA.getStub<IGreet>("foo.my-greeting").getGreeting("World"),
       "Hello, World! [from B]");
     assert.equal(await AtoB.callRemoteFunc("func", "Santa"), "Yo Santa [from B]");
-    assert.equal(await CtoA.callRemoteFuncForward("foo", "func", "Santa"), "Yo Santa [from B]");
+    assert.equal(await CtoA.callRemoteFunc("foo.func", "Santa"), "Yo Santa [from B]");
 
     assert.equal(await AtoC.getStub<IGreet>("my-greeting").getGreeting("World"),
       "Hello, World! [from C]");
-    assert.equal(await DtoB.getStubForward<IGreet>("bar", "my-greeting").getGreeting("World"),
+    assert.equal(await DtoB.getStub<IGreet>("bar.my-greeting").getGreeting("World"),
       "Hello, World! [from C]");
     assert.equal(await AtoC.callRemoteFunc("func", "Santa"), "Yo Santa [from C]");
-    assert.equal(await DtoB.callRemoteFuncForward("bar", "func", "Santa"), "Yo Santa [from C]");
+    assert.equal(await DtoB.callRemoteFunc("bar.func", "Santa"), "Yo Santa [from C]");
 
     // Test forwarding of custom messages.
     let p: Promise<any>;

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -1,4 +1,5 @@
 import {assert} from "chai";
+import {EventEmitter} from "events";
 import {Rpc} from "../lib/rpc";
 
 interface ICalc {
@@ -20,8 +21,11 @@ class MyGreeting implements IGreet {
   public async getGreeting(name: string): Promise<string> { return `Hello, ${name}!${this.suffix}`; }
 }
 
-describe("ts-rpc", () => {
+function waitForEvent(emitter: EventEmitter, eventName: string): Promise<any> {
+  return new Promise((resolve) => emitter.once(eventName, resolve));
+}
 
+describe("ts-rpc", () => {
   it("should be able to make unchecked stubs and call methods", async () => {
     const rpc = new Rpc();
     rpc.start((msg) => rpc.receiveMessage(msg));
@@ -52,12 +56,12 @@ describe("ts-rpc", () => {
     //             |    |      |AtoC| <--> |CtoA|
     // |DtoB| <--> |BtoD|
 
-    // Allow C to call to B by calling A with "foo." prefix.
-    AtoC.registerForwarder("foo.", "", AtoB);
+    // Allow C to call to B by calling A with "foo" forwarder.
+    AtoC.registerForwarder("foo", AtoB);
 
-    // Allow D to call to C via B and A with "bar." prefix.
-    BtoD.registerForwarder("bar.", "bar.", BtoA);
-    AtoB.registerForwarder("bar.", "", AtoC);
+    // Allow D to call to C via B and A with "bar" forwarder.
+    BtoD.registerForwarder("bar", BtoA, "bar");
+    AtoB.registerForwarder("bar", AtoC);
 
     BtoA.registerImpl("my-greeting", new MyGreeting(" [from B]"));
     BtoA.registerFunc("func", async (name: string) => `Yo ${name} [from B]`);
@@ -65,15 +69,37 @@ describe("ts-rpc", () => {
     CtoA.registerImpl("my-greeting", new MyGreeting(" [from C]"));
     CtoA.registerFunc("func", async (name: string) => `Yo ${name} [from C]`);
 
-    assert.equal(await AtoB.getStub<IGreet>("my-greeting").getGreeting("World"), "Hello, World! [from B]");
-    assert.equal(await CtoA.getStub<IGreet>("foo.my-greeting").getGreeting("World"), "Hello, World! [from B]");
+    assert.equal(await AtoB.getStub<IGreet>("my-greeting").getGreeting("World"),
+      "Hello, World! [from B]");
+    assert.equal(await CtoA.getStubForward<IGreet>("foo", "my-greeting").getGreeting("World"),
+      "Hello, World! [from B]");
     assert.equal(await AtoB.callRemoteFunc("func", "Santa"), "Yo Santa [from B]");
-    assert.equal(await CtoA.callRemoteFunc("foo.func", "Santa"), "Yo Santa [from B]");
+    assert.equal(await CtoA.callRemoteFuncForward("foo", "func", "Santa"), "Yo Santa [from B]");
 
-    assert.equal(await AtoC.getStub<IGreet>("my-greeting").getGreeting("World"), "Hello, World! [from C]");
-    assert.equal(await DtoB.getStub<IGreet>("bar.my-greeting").getGreeting("World"), "Hello, World! [from C]");
+    assert.equal(await AtoC.getStub<IGreet>("my-greeting").getGreeting("World"),
+      "Hello, World! [from C]");
+    assert.equal(await DtoB.getStubForward<IGreet>("bar", "my-greeting").getGreeting("World"),
+      "Hello, World! [from C]");
     assert.equal(await AtoC.callRemoteFunc("func", "Santa"), "Yo Santa [from C]");
-    assert.equal(await DtoB.callRemoteFunc("bar.func", "Santa"), "Yo Santa [from C]");
+    assert.equal(await DtoB.callRemoteFuncForward("bar", "func", "Santa"), "Yo Santa [from C]");
+
+    // Test forwarding of custom messages.
+    let p: Promise<any>;
+    p = waitForEvent(AtoC, "message");
+    await CtoA.postMessage({hello: 1});
+    assert.deepEqual(await p, {hello: 1});
+
+    p = waitForEvent(BtoA, "message");
+    await CtoA.postMessageForward("foo", {hello: 2});
+    assert.deepEqual(await p, {hello: 2});
+
+    p = waitForEvent(BtoD, "message");
+    await DtoB.postMessage({world: 3});
+    assert.deepEqual(await p, {world: 3});
+
+    p = waitForEvent(CtoA, "message");
+    await DtoB.postMessageForward("bar", {world: 4});
+    assert.deepEqual(await p, {world: 4});
   });
 });
 


### PR DESCRIPTION
Small modifications to @dsagal's #5 PR toward something that I will be even happier using. This includes: 

1. removing most of the -Forward methods in favour of prefixing names with the destination (`callRemoteFuncForward("foo", "func")` <- `callRemoteFunc("foo.func")`).
2. hiding `fwdDest` argument from the registerForwarder (I believe most of the time call are forwarded all the way with the same name).

What remains to be done:
 - Merging `postMessage` and `postMessageForward` together.