### PR TITLE
When proxying an unchecked interface, omit "then" method by default

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -161,7 +161,8 @@ export class Rpc extends EventEmitter {
       return new Proxy({}, {
         get: (target, property: string, receiver) => {
           if (property === "then") {
-            // By default, take care not to look "thenable":
+            // By default, take care not to look "thenable", so that the stub can be returned
+            // as a value of a Promise:
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
             // If user really wants to proxy "then", they can write a checker.
             return undefined;

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -160,6 +160,12 @@ export class Rpc extends EventEmitter {
       // TODO Test, then explain how this works.
       return new Proxy({}, {
         get: (target, property: string, receiver) => {
+          if (property === "then") {
+            // By default, take care not to look "thenable":
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
+            // If user really wants to proxy "then", they can write a checker.
+            return undefined;
+          }
           return (...args: any[]) => this._makeCall(name, property, args, anyChecker);
         },
       });

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -48,7 +48,7 @@ describe("ts-rpc", () => {
 
   describe("getStub", () => {
 
-    it("should not look thenable for unchecked interfaces", async () => {
+    it("should be able to return safely from async methods", async () => {
       const rpc = new Rpc(defaults);
       rpc.start((msg) => rpc.receiveMessage(msg));
       rpc.registerImpl<ICalc>("calc", new Calc());
@@ -60,6 +60,14 @@ describe("ts-rpc", () => {
       const stub = await getCalc();
       assert(stub);
       assert.equal(await stub.add(4, 5), 9);
+    });
+
+    it("should be able to pass through Promise.resolve", async () => {
+      const rpc = new Rpc(defaults);
+      rpc.start((msg) => rpc.receiveMessage(msg));
+      rpc.registerImpl<ICalc>("calc", new Calc());
+      const stub = Promise.resolve(rpc.getStub<ICalc>("calc"));
+      assert.equal(await stub.then(calc => calc.add(4, 5)), 9);
     });
 
   });

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -19,25 +19,48 @@ class MyGreeting implements IGreet {
   public async getGreeting(name: string): Promise<string> { return `Hello, ${name}!`; }
 }
 
+const defaults = { logger: {} };
+
 describe("ts-rpc", () => {
 
-  it("should be able to make unchecked stubs and call methods", async () => {
-    const rpc = new Rpc();
-    rpc.start((msg) => rpc.receiveMessage(msg));
-    rpc.registerImpl<ICalc>("calc", new Calc());
-    const stub = rpc.getStub<ICalc>("calc");
-    assert(stub);
-    assert.equal(await stub.add(4, 5), 9);
+  describe("basics", () => {
+
+    it("should be able to make unchecked stubs and call methods", async () => {
+      const rpc = new Rpc(defaults);
+      rpc.start((msg) => rpc.receiveMessage(msg));
+      rpc.registerImpl<ICalc>("calc", new Calc());
+      const stub = rpc.getStub<ICalc>("calc");
+      assert(stub);
+      assert.equal(await stub.add(4, 5), 9);
+    });
+
+    it("should support hello world without a checker", async () => {
+      const aRpc = new Rpc(defaults);
+      const bRpc = new Rpc(defaults);
+      aRpc.start((msg) => bRpc.receiveMessage(msg));
+      bRpc.start((msg) => aRpc.receiveMessage(msg));
+      aRpc.registerImpl("my-greeting", new MyGreeting());
+      const stub = bRpc.getStub<IGreet>("my-greeting");
+      assert.equal(await stub.getGreeting("World"), "Hello, World!");
+    });
+
   });
 
-  it("should support hello world without a checker", async () => {
-    const aRpc = new Rpc();
-    const bRpc = new Rpc();
-    aRpc.start((msg) => bRpc.receiveMessage(msg));
-    bRpc.start((msg) => aRpc.receiveMessage(msg));
-    aRpc.registerImpl("my-greeting", new MyGreeting());
-    const stub = bRpc.getStub<IGreet>("my-greeting");
-    assert.equal(await stub.getGreeting("World"), "Hello, World!");
-  });
+  describe("getStub", () => {
 
+    it("should not look thenable for unchecked interfaces", async () => {
+      const rpc = new Rpc(defaults);
+      rpc.start((msg) => rpc.receiveMessage(msg));
+      rpc.registerImpl<ICalc>("calc", new Calc());
+      // Unchecked stubs will not return well from async methods if they look thenable
+      // and javascript code results in a Promise.resolve.
+      async function getCalc() {
+        return rpc.getStub<ICalc>("calc");
+      }
+      const stub = await getCalc();
+      assert(stub);
+      assert.equal(await stub.add(4, 5), 9);
+    });
+
+  });
 });


### PR DESCRIPTION
The behavior of `Promise.resolve(obj)` depends on whether `obj` appears to have a `then` method.  To make stubs for unchecked interfaces safe to pass through `Promise.resolve`, this commit specifically avoids proxying the `then` property.  A user who actually wants a `then` method can use a checked interface.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve