### PR TITLE
sketch out a way of passing along and unpacking scope information

### DIFF
--- a/lib/message.ts
+++ b/lib/message.ts
@@ -23,6 +23,7 @@ export interface IMsgRpcCall {
   iface: string;
   meth: string;
   args: any[];
+  scope?: {[name: string]: any};  // Optional identity information.
 }
 
 // Message describing an RPC successful response.

--- a/test/ICalc-ti.ts
+++ b/test/ICalc-ti.ts
@@ -5,7 +5,12 @@ export const ICalc = t.iface([], {
   "add": t.func("number", t.param("x", "number"), t.param("y", "number")),
 });
 
+export const IScopedCalc = t.iface([], {
+  "add": t.func("number", t.param("scope", "string"), t.param("x", "number"), t.param("y", "number")),
+});
+
 const exportedTypeSuite: t.ITypeSuite = {
   ICalc,
+  IScopedCalc,
 };
 export default exportedTypeSuite;

--- a/test/ICalc.ts
+++ b/test/ICalc.ts
@@ -1,3 +1,7 @@
 export interface ICalc {
   add(x: number, y: number): number;
 }
+
+export interface IScopedCalc {
+  add(scope: string, x: number, y: number): number;
+}


### PR DESCRIPTION
This adds a way to add and use scope information (session identifiers, plugin names, etc).

Rpc objects can now have named `scope` fields.  Any method invocations passing through them have this scope added to them. When implementations are registered, scope fields can be prepended to the list of arguments in calls.

So, for example, imagine we want users to call `foo.add(4, 5)` but our implementation to see `foo.add(session_id, plugin_id, 4, 5)`. Then the implementation would be registered with `registerScopedImpl(..., ["session_id", "plugin_id"], ...)` and Rpc objects between the user and the implementation should somewhere set a `session_id` and `plugin_id`.  See test cases.

Not sure if this is a good way to go.  Better than some alternatives I've tried :-).  Seems like it could be clean enough.  For type checking, you do need to have two separate interfaces, which seems a bit silly, but could be fixed by some more `ts-interface-checker` magic.  It does add one more field to the call object.