### PR TITLE
Add an option to wrap calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,15 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.57",
+    "@types/sinon": "^5.0.1",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.0",
     "mocha": "^3.5.3",
     "nyc": "^11.4.1",
+    "sinon": "^6.0.0",
     "ts-interface-builder": "^0.1.1",
     "ts-node": "^4.0.1",
-    "typescript": "^2.6.2"
+    "typescript": "^2.9.2"
   }
 }

--- a/test/test_rpc.ts
+++ b/test/test_rpc.ts
@@ -250,9 +250,6 @@ describe("Rpc", () => {
     await stub.add(4, 5);
     assert.equal(before.callCount, 1);
     assert.equal(after.callCount, 1);
-    await rpc.postMessage("test");
-    assert.equal(before.callCount, 2);
-    assert.equal(after.callCount, 2);
   });
 
 });


### PR DESCRIPTION
This commit introduces the `callWrapper` option that let you wrap the calls before any message is sent.

A `callWrapper` should expect as argument the  function that triggers the call. And it must return the call result if any.

This commit adds a dev dependency to `sinon` and `@types/sinon` and update `typescript` to fix a compilation error that was caused by `@types/sinon/index.d.ts`.