### PR TITLE
Add separate methods for queueing and processing send/receive queues

### DIFF
--- a/lib/message.ts
+++ b/lib/message.ts
@@ -12,6 +12,7 @@ export enum MsgType {
   RpcRespData = 2,
   RpcRespErr = 3,
   Custom = 4,       // Used for any non-RPC messages.
+  Ready = 5,
 }
 
 // Message describing an RPC call.
@@ -49,8 +50,12 @@ export interface IMsgCustom {
   data: any;
 }
 
+export interface IMsgReady {
+  mtype: MsgType.Ready;
+}
+
 // Type of all RPC messages.
 export type IMsgRpc = IMsgRpcCall | IMsgRpcRespData | IMsgRpcRespErr;
 
 // Type for any message that may be sent over an RpcChannel.
-export type IMessage = IMsgRpc | IMsgCustom;
+export type IMessage = IMsgRpc | IMsgCustom | IMsgReady;

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -159,7 +159,12 @@ export class Rpc extends EventEmitter implements IForwarderDest {
   public setSendMessage(sendMessage: SendMessageCB|null) {
     this._sendMessageCB = sendMessage;
     if (this._sendMessageCB) {
-      this._processOutgoing();
+      try {
+        this._processOutgoing();
+      } catch (e) {
+        this.emit("error", e);
+        throw e;
+      }
     } else {
       this._queueOutgoing();
     }
@@ -403,7 +408,12 @@ export class Rpc extends EventEmitter implements IForwarderDest {
       case MsgType.RpcRespData:
       case MsgType.RpcRespErr: { this._onMessageResp(msg); return; }
       case MsgType.Custom: { this._onCustomMessage(msg); return; }
-      case MsgType.Ready: { this._waitForReadyMessage = false; this._processOutgoing(); return; }
+      case MsgType.Ready: {
+        this._waitForReadyMessage = false;
+        try { this._processOutgoing(); } catch (e) { this.emit("error", e); }
+        return;
+
+      }
     }
   }
 

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -159,12 +159,7 @@ export class Rpc extends EventEmitter implements IForwarderDest {
   public setSendMessage(sendMessage: SendMessageCB|null) {
     this._sendMessageCB = sendMessage;
     if (this._sendMessageCB) {
-      try {
-        this._processOutgoing();
-      } catch (e) {
-        this.emit("error", e);
-        throw e;
-      }
+      this._processOutgoing();
     } else {
       this._queueOutgoing();
     }
@@ -376,6 +371,7 @@ export class Rpc extends EventEmitter implements IForwarderDest {
         callObj.reject(newErr);
       }
     }
+    this.emit("error", newErr);
     throw newErr;
   }
 
@@ -410,9 +406,8 @@ export class Rpc extends EventEmitter implements IForwarderDest {
       case MsgType.Custom: { this._onCustomMessage(msg); return; }
       case MsgType.Ready: {
         this._waitForReadyMessage = false;
-        try { this._processOutgoing(); } catch (e) { this.emit("error", e); }
+        try { this._processOutgoing(); } catch (e) { /* swallowing error, an event 'error' was already emitted */ }
         return;
-
       }
     }
   }


### PR DESCRIPTION
This is my attempt at separating the queuing of sent and received messages, i.e. alternative to #21. In this diff, I am trying to separate each logical thing a user of Rpc may need into its own method.  The result is that there are more methods, but each method has a simple description and clear behavior. 

Existing unittests pass, but I have not added new ones pending review of the approach.